### PR TITLE
Add class-wise contrastive alignment for UDA segmentation

### DIFF
--- a/cls/README.md
+++ b/cls/README.md
@@ -44,7 +44,25 @@ found in [experiments.py](experiments.py).
 The experiment progress is logged on Weights&Biases.
 
 For VisDA-2017, the mean over the class accuracies is reported. This value is denoted
-as 'mean correct' in the logs as explained in https://github.com/val-iisc/SDAT/issues/1. 
+as 'mean correct' in the logs as explained in https://github.com/val-iisc/SDAT/issues/1.
+
+## Feature visualization
+
+You can visualize the feature distribution of a trained model with a t-SNE plot
+using the helper script in `examples/plot_tsne.py`. The script restores the
+classifier checkpoint, collects features for both domains and writes the
+visualization to disk:
+
+```shell
+python examples/plot_tsne.py \
+  --data OfficeHome --root examples/data \
+  --source Art --target Clipart \
+  --arch resnet50 --checkpoint <path-to-checkpoint> \
+  --output outputs/officehome_art2clipart_tsne.pdf --max-samples 1000
+```
+
+Use `--max-samples` to subsample the features for quicker experimentation or
+`--max-batches` to limit the number of batches collected per domain.
 
 ## Where to find MIC in the code?
 

--- a/cls/common/utils/analysis/tsne.py
+++ b/cls/common/utils/analysis/tsne.py
@@ -13,7 +13,8 @@ import matplotlib.colors as col
 
 
 def visualize(source_feature: torch.Tensor, target_feature: torch.Tensor,
-              filename: str, source_color='r', target_color='b'):
+              filename: str, source_color: str = 'r', target_color: str = 'b',
+              random_state: int = 33):
     """
     Visualize features from different domains using t-SNE.
 
@@ -23,6 +24,8 @@ def visualize(source_feature: torch.Tensor, target_feature: torch.Tensor,
         filename (str): the file name to save t-SNE
         source_color (str): the color of the source features. Default: 'r'
         target_color (str): the color of the target features. Default: 'b'
+        random_state (int): random seed passed to :class:`sklearn.manifold.TSNE`.
+            Default: 33.
 
     """
     source_feature = source_feature.numpy()
@@ -30,7 +33,7 @@ def visualize(source_feature: torch.Tensor, target_feature: torch.Tensor,
     features = np.concatenate([source_feature, target_feature], axis=0)
 
     # map features to 2-d using TSNE
-    X_tsne = TSNE(n_components=2, random_state=33).fit_transform(features)
+    X_tsne = TSNE(n_components=2, random_state=random_state).fit_transform(features)
 
     # domain labels, 1 represents source while 0 represents target
     domains = np.concatenate((np.ones(len(source_feature)), np.zeros(len(target_feature))))

--- a/cls/examples/plot_tsne.py
+++ b/cls/examples/plot_tsne.py
@@ -1,0 +1,218 @@
+"""Utility script to visualize feature distributions with t-SNE.
+
+This helper mirrors the analysis phase implemented in
+``examples/cdan_mcc_sdat.py`` but exposes it as a light-weight command line
+tool.  Given a trained classification checkpoint, the script extracts
+features for the specified source and target domains and stores a t-SNE plot
+on disk.
+"""
+
+import argparse
+import os
+import os.path as osp
+import sys
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+
+def _extend_sys_path() -> None:
+    """Register project modules so that the script can be executed in-place."""
+
+    current_dir = osp.dirname(osp.abspath(__file__))
+    project_root = osp.abspath(osp.join(current_dir, os.pardir))
+
+    if project_root not in sys.path:
+        sys.path.append(project_root)
+    if current_dir not in sys.path:
+        sys.path.append(current_dir)
+
+
+_extend_sys_path()
+
+from dalib.adaptation.cdan import ImageClassifier  # noqa: E402
+from common.utils.analysis import collect_feature, tsne  # noqa: E402
+
+import utils  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments for the t-SNE visualization script."""
+
+    default_device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    parser = argparse.ArgumentParser(
+        description="Plot a t-SNE visualization for source and target features",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument('--data', default='OfficeHome',
+                        choices=utils.get_dataset_names(),
+                        help='dataset name')
+    parser.add_argument('--root', default='examples/data',
+                        help='root directory for datasets')
+    parser.add_argument('--source', nargs='+', required=True,
+                        help='source domain(s) used during training')
+    parser.add_argument('--target', nargs='+', required=True,
+                        help='target domain(s) used during training')
+    parser.add_argument('--arch', default='resnet50',
+                        choices=utils.get_model_names(),
+                        help='backbone architecture')
+    parser.add_argument('--checkpoint', required=True,
+                        help='path to a trained classifier checkpoint')
+    parser.add_argument('--batch-size', type=int, default=64,
+                        help='mini-batch size for feature extraction')
+    parser.add_argument('--workers', type=int, default=4,
+                        help='number of data loading workers')
+    parser.add_argument('--val-resizing', default='default', choices=['default', 'res.'],
+                        help='resizing mode for feature extraction')
+    parser.add_argument('--resize-size', type=int, default=224,
+                        help='resize size when using "res." mode')
+    parser.add_argument('--norm-mean', type=float, nargs=3,
+                        default=(0.485, 0.456, 0.406),
+                        metavar=('R', 'G', 'B'),
+                        help='normalization mean for the transforms')
+    parser.add_argument('--norm-std', type=float, nargs=3,
+                        default=(0.229, 0.224, 0.225),
+                        metavar=('R', 'G', 'B'),
+                        help='normalization std for the transforms')
+    parser.add_argument('--bottleneck-dim', type=int, default=256,
+                        help='feature dimension of the bottleneck layer')
+    parser.add_argument('--no-pool', action='store_true',
+                        help='disable the global pooling layer')
+    parser.add_argument('--scratch', action='store_true',
+                        help='initialize the backbone from scratch')
+    parser.add_argument('--max-batches', type=int, default=None,
+                        help='number of mini-batches per domain to extract features from')
+    parser.add_argument('--max-samples', type=int, default=None,
+                        help='limit the number of features per domain before running t-SNE')
+    parser.add_argument('--output', default=None,
+                        help='where to store the resulting visualization')
+    parser.add_argument('--source-color', default='r',
+                        help='color used for source domain samples')
+    parser.add_argument('--target-color', default='b',
+                        help='color used for target domain samples')
+    parser.add_argument('--random-state', type=int, default=33,
+                        help='random seed for sklearn.manifold.TSNE')
+    parser.add_argument('--device', default=default_device,
+                        help='device used for feature extraction')
+    return parser.parse_args()
+
+
+def _prepare_transforms(args: argparse.Namespace) -> Tuple[object, object]:
+    """Construct the transforms used to extract features."""
+
+    transform = utils.get_val_transform(
+        args.val_resizing,
+        resize_size=args.resize_size,
+        norm_mean=tuple(args.norm_mean),
+        norm_std=tuple(args.norm_std),
+    )
+    return transform, transform
+
+
+def _create_dataloaders(args: argparse.Namespace, device: torch.device):
+    """Instantiate the dataloaders for source and target domains."""
+
+    train_transform, val_transform = _prepare_transforms(args)
+    source_dataset, target_dataset, _, _, num_classes, _ = utils.get_dataset(
+        args.data,
+        args.root,
+        args.source,
+        args.target,
+        train_transform,
+        val_transform,
+        train_target_transform=train_transform,
+    )
+    common_loader_args = dict(
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.workers,
+        pin_memory=device.type == 'cuda',
+    )
+    source_loader = DataLoader(source_dataset, **common_loader_args)
+    target_loader = DataLoader(target_dataset, **common_loader_args)
+    return source_loader, target_loader, num_classes
+
+
+def _build_classifier(args: argparse.Namespace, num_classes: int, device: torch.device) -> nn.Module:
+    """Restore a classifier from the checkpoint provided by the user."""
+
+    backbone = utils.get_model(args.arch, pretrain=not args.scratch)
+    pool_layer = nn.Identity() if args.no_pool else None
+    classifier = ImageClassifier(
+        backbone,
+        num_classes,
+        bottleneck_dim=args.bottleneck_dim,
+        pool_layer=pool_layer,
+        finetune=not args.scratch,
+    ).to(device)
+
+    checkpoint = torch.load(args.checkpoint, map_location=device)
+    classifier.load_state_dict(checkpoint)
+    classifier.eval()
+
+    feature_extractor = nn.Sequential(
+        classifier.backbone,
+        classifier.pool_layer,
+        classifier.bottleneck,
+    )
+    feature_extractor.to(device)
+    return feature_extractor
+
+
+def _limit_samples(feature: torch.Tensor, limit: int) -> torch.Tensor:
+    """Restrict the number of features returned by ``collect_feature``."""
+
+    if limit is None:
+        return feature
+    if feature.size(0) <= limit:
+        return feature
+    return feature[:limit]
+
+
+def main() -> None:
+    args = parse_args()
+
+    device = torch.device(args.device)
+    if device.type == 'cuda' and not torch.cuda.is_available():
+        raise RuntimeError('CUDA device requested but not available on this machine.')
+
+    source_loader, target_loader, num_classes = _create_dataloaders(args, device)
+    feature_extractor = _build_classifier(args, num_classes, device)
+
+    source_features = collect_feature(
+        source_loader, feature_extractor, device, max_num_features=args.max_batches)
+    target_features = collect_feature(
+        target_loader, feature_extractor, device, max_num_features=args.max_batches)
+
+    if args.max_samples is not None:
+        source_features = _limit_samples(source_features, args.max_samples)
+        target_features = _limit_samples(target_features, args.max_samples)
+
+    if args.output is None:
+        source_name = '-'.join(args.source)
+        target_name = '-'.join(args.target)
+        output_path = f'tsne_{source_name}_to_{target_name}.pdf'
+    else:
+        output_path = args.output
+
+    output_dir = osp.dirname(output_path)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+
+    tsne.visualize(
+        source_features,
+        target_features,
+        output_path,
+        source_color=args.source_color,
+        target_color=args.target_color,
+        random_state=args.random_state,
+    )
+
+    print(f'Saved t-SNE visualization to {output_path}')
+
+
+if __name__ == '__main__':
+    main()
+

--- a/seg/README.md
+++ b/seg/README.md
@@ -149,6 +149,26 @@ python -m tools.test path/to/config_file path/to/checkpoint_file --test-set --fo
 The predictions can be submitted to the public evaluation server of the
 respective dataset to obtain the test score.
 
+## Feature Visualization
+
+You can inspect how the model separates target-domain categories by sampling
+pixel logits and visualizing them with t-SNE:
+
+```shell
+python tools/plot_target_tsne.py \
+    configs/mic/gtaHR2csHR_mic_hrda.py \
+    path/to/checkpoint.pth \
+    --output work_dirs/tsne_target.png \
+    --max-images 40 \
+    --max-per-class 1024 \
+    --device cuda:0
+```
+
+The script follows the data pipeline defined in the configuration and colors
+points according to the ground-truth target labels. Pass `--use-predictions`
+when ground-truth masks are unavailable and optionally store the sampled logits
+with `--save-data`.
+
 ## Checkpoints
 
 Below, we provide checkpoints of MIC(HRDA) for the different benchmarks.

--- a/seg/configs/mic/gtaHR2csHR_mic_hrda.py
+++ b/seg/configs/mic/gtaHR2csHR_mic_hrda.py
@@ -83,6 +83,14 @@ uda = dict(
     # and a mask ratio of 0.7
     mask_generator=dict(
         type='block', mask_ratio=0.7, mask_block_size=64, _delete_=True))
+uda.update(dict(
+    contrastive=dict(
+        enable=True,
+        temperature=0.07,
+        loss_weight=1.0,
+        min_pixels=256,
+        max_samples=4096,
+        normalize=True)))
 # Optimizer Hyperparameters
 optimizer_config = None
 optimizer = dict(

--- a/seg/mmseg/models/uda/__init__.py
+++ b/seg/mmseg/models/uda/__init__.py
@@ -6,7 +6,8 @@
 # ---------------------------------------------------------------
 
 from mmseg.models.uda.advseg import AdvSeg
+from mmseg.models.uda.classwise_contrast import ClasswiseContrastiveLoss
 from mmseg.models.uda.dacs import DACS
 from mmseg.models.uda.minent import MinEnt
 
-__all__ = ['DACS', 'MinEnt', 'AdvSeg']
+__all__ = ['DACS', 'MinEnt', 'AdvSeg', 'ClasswiseContrastiveLoss']

--- a/seg/mmseg/models/uda/classwise_contrast.py
+++ b/seg/mmseg/models/uda/classwise_contrast.py
@@ -1,0 +1,185 @@
+"""Class-wise contrastive alignment helpers for UDA segmentation."""
+
+# ---------------------------------------------------------------
+# Copyright (c) 2024.
+# Licensed under the Apache License, Version 2.0
+# ---------------------------------------------------------------
+
+from typing import Dict, Optional, Sequence, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class ClasswiseContrastiveLoss(nn.Module):
+    """Class-wise contrastive alignment for UDA segmentation.
+
+    The module builds class prototypes from source and target feature maps and
+    optimizes an InfoNCE objective so that prototypes from the same class
+    become closer while prototypes from different classes are pushed apart.
+
+    Args:
+        num_classes (int): Number of semantic classes.
+        temperature (float): Softmax temperature used for the InfoNCE loss.
+        loss_weight (float): Multiplicative weight for the resulting loss.
+        min_pixels (int): Minimal number of valid pixels per class that is
+            required to form a prototype.
+        max_samples (int, optional): Maximum number of pixels sampled per class
+            to build the prototype. ``None`` keeps all pixels.
+        normalize (bool): Whether to L2-normalize prototypes before computing
+            similarities.
+    """
+
+    def __init__(
+        self,
+        num_classes: int,
+        temperature: float = 0.1,
+        loss_weight: float = 1.0,
+        min_pixels: int = 0,
+        max_samples: Optional[int] = None,
+        normalize: bool = True,
+    ) -> None:
+        super().__init__()
+        self.num_classes = num_classes
+        self.temperature = temperature
+        self.loss_weight = loss_weight
+        self.min_pixels = min_pixels
+        self.max_samples = max_samples
+        self.normalize = normalize
+
+    @staticmethod
+    def _maybe_resize(
+        tensor: torch.Tensor,
+        size_hw: Sequence[int],
+        mode: str = 'nearest',
+    ) -> torch.Tensor:
+        if tensor.shape[-2:] == tuple(size_hw):
+            return tensor
+        if tensor.dim() == 3:
+            tensor = tensor.unsqueeze(1)
+            resized = F.interpolate(tensor.float(), size=size_hw, mode=mode)
+            return resized.squeeze(1)
+        return F.interpolate(tensor.float(), size=size_hw, mode=mode)
+
+    def _flatten_features(
+        self,
+        feat: torch.Tensor,
+        labels: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+        """Reshape spatial features and labels into flat tensors."""
+        if labels.dim() == 4:
+            labels = labels.squeeze(1)
+        feat = feat.permute(0, 2, 3, 1).reshape(-1, feat.shape[1])
+        labels = labels.reshape(-1)
+        if mask is not None:
+            mask = mask.reshape(-1)
+        return feat, labels, mask
+
+    def _compute_prototypes(
+        self,
+        feat: torch.Tensor,
+        labels: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[Dict[int, torch.Tensor], Dict[int, float]]:
+        """Compute class-wise prototypes using (optional) weights."""
+        if mask is not None:
+            valid = (labels >= 0) & (labels < self.num_classes) & mask.bool()
+            weights = mask[valid].float()
+        else:
+            valid = (labels >= 0) & (labels < self.num_classes)
+            weights = None
+        feat = feat[valid]
+        labels = labels[valid]
+        if weights is not None:
+            weights = weights.float()
+        if feat.numel() == 0:
+            return {}, {}
+
+        classes, inverse, counts = labels.unique(
+            return_inverse=True, return_counts=True)
+        prototypes: Dict[int, torch.Tensor] = {}
+        used_counts: Dict[int, float] = {}
+        for idx, cls in enumerate(classes.tolist()):
+            cls_mask = inverse == idx
+            indices = torch.nonzero(cls_mask, as_tuple=False).squeeze(1)
+            if indices.numel() == 0:
+                continue
+            if self.min_pixels and indices.numel() < self.min_pixels:
+                continue
+            perm = None
+            if self.max_samples is not None and \
+                    indices.numel() > self.max_samples:
+                perm = torch.randperm(indices.numel(), device=feat.device)
+                perm = perm[:self.max_samples]
+                indices = indices[perm]
+            cls_feat = feat[indices]
+            if weights is not None:
+                cls_weights = weights[cls_mask]
+                if perm is not None:
+                    cls_weights = cls_weights[perm]
+                weight_sum = cls_weights.sum()
+                if weight_sum.item() <= 0:
+                    continue
+                prototype = (cls_feat * cls_weights.unsqueeze(1)).sum(0) / weight_sum
+                used_counts[cls] = float(weight_sum.item())
+            else:
+                prototype = cls_feat.mean(0)
+                used_counts[cls] = float(cls_feat.shape[0])
+            prototypes[cls] = prototype
+        return prototypes, used_counts
+
+    def forward(
+        self,
+        src_feat: torch.Tensor,
+        src_label: torch.Tensor,
+        tgt_feat: torch.Tensor,
+        tgt_label: torch.Tensor,
+        tgt_mask: Optional[torch.Tensor] = None,
+    ) -> Optional[Tuple[Dict[str, torch.Tensor], Dict[str, torch.Tensor]]]:
+        """Compute the class-wise contrastive alignment loss."""
+        feat_hw = src_feat.shape[-2:]
+        src_label = self._maybe_resize(src_label, feat_hw, mode='nearest').long()
+        tgt_label = self._maybe_resize(tgt_label, feat_hw, mode='nearest').long()
+        tgt_mask_tensor: Optional[torch.Tensor] = None
+        if tgt_mask is not None:
+            tgt_mask_tensor = self._maybe_resize(tgt_mask.float(), feat_hw, mode='nearest')
+            tgt_mask_tensor = tgt_mask_tensor.squeeze(1) if tgt_mask_tensor.dim() == 4 else tgt_mask_tensor
+
+        src_feat_flat, src_label_flat, _ = self._flatten_features(src_feat, src_label)
+        tgt_feat_flat, tgt_label_flat, tgt_mask_flat = self._flatten_features(
+            tgt_feat, tgt_label, tgt_mask_tensor)
+
+        src_proto, src_counts = self._compute_prototypes(src_feat_flat, src_label_flat)
+        tgt_proto, tgt_counts = self._compute_prototypes(
+            tgt_feat_flat, tgt_label_flat, tgt_mask_flat)
+
+        common = sorted(set(src_proto.keys()) & set(tgt_proto.keys()))
+        if not common:
+            return None
+
+        src_stack = torch.stack([src_proto[c] for c in common], dim=0)
+        tgt_stack = torch.stack([tgt_proto[c] for c in common], dim=0)
+        if self.normalize:
+            src_stack = F.normalize(src_stack, dim=1)
+            tgt_stack = F.normalize(tgt_stack, dim=1)
+        logits = torch.mm(src_stack, tgt_stack.t()) / self.temperature
+        targets = torch.arange(len(common), device=logits.device)
+
+        row_loss = F.cross_entropy(logits, targets, reduction='none')
+        col_loss = F.cross_entropy(logits.t(), targets, reduction='none')
+        weights = src_stack.new_tensor([
+            max(min(src_counts[c], tgt_counts[c]), 1.0) for c in common
+        ])
+        weights = weights / weights.sum()
+        loss = 0.5 * ((row_loss * weights).sum() + (col_loss * weights).sum())
+        loss = loss * self.loss_weight
+
+        diag_sim = logits.diag().detach()
+        stats = {
+            'num_classes': logits.new_tensor(float(len(common))),
+            'pos_sim': diag_sim.mean() if diag_sim.numel() > 0 else logits.new_tensor(0.0),
+        }
+        losses = {'loss_contrast': loss}
+        return losses, stats

--- a/seg/mmseg/models/uda/dacs.py
+++ b/seg/mmseg/models/uda/dacs.py
@@ -31,6 +31,7 @@ from torch.nn.modules.dropout import _DropoutNd
 from mmseg.core import add_prefix
 from mmseg.models import UDA, HRDAEncoderDecoder, build_segmentor
 from mmseg.models.segmentors.hrda_encoder_decoder import crop
+from mmseg.models.uda.classwise_contrast import ClasswiseContrastiveLoss
 from mmseg.models.uda.masking_consistency_module import \
     MaskingConsistencyModule
 from mmseg.models.uda.uda_decorator import UDADecorator, get_module
@@ -99,6 +100,16 @@ class DACS(UDADecorator):
             self.imnet_model = build_segmentor(deepcopy(cfg['model']))
         else:
             self.imnet_model = None
+
+        contrast_cfg = deepcopy(cfg.get('contrastive', None))
+        self.contrastive_align = None
+        self.enable_contrastive = False
+        if contrast_cfg:
+            enable = contrast_cfg.pop('enable', True)
+            if enable:
+                contrast_cfg.setdefault('num_classes', self.num_classes)
+                self.contrastive_align = ClasswiseContrastiveLoss(**contrast_cfg)
+                self.enable_contrastive = True
 
     def get_ema_model(self):
         return get_module(self.ema_model)
@@ -251,6 +262,15 @@ class DACS(UDADecorator):
         feat_log.pop('loss', None)
         return feat_loss, feat_log
 
+    def _select_contrastive_feat(self, feat):
+        if isinstance(feat, (list, tuple)):
+            return self._select_contrastive_feat(feat[-1])
+        if isinstance(feat, dict):
+            # Take the last key deterministically to keep alignment stable
+            key = sorted(feat.keys())[-1]
+            return self._select_contrastive_feat(feat[key])
+        return feat
+
     def update_debug_state(self):
         debug = self.local_iter % self.debug_img_interval == 0
         self.get_model().automatic_debug = False
@@ -264,25 +284,35 @@ class DACS(UDADecorator):
     def get_pseudo_label_and_weight(self, logits):
         ema_softmax = torch.softmax(logits.detach(), dim=1)
         pseudo_prob, pseudo_label = torch.max(ema_softmax, dim=1)
-        ps_large_p = pseudo_prob.ge(self.pseudo_threshold).long() == 1
+        ps_large_p = pseudo_prob.ge(self.pseudo_threshold)
         ps_size = np.size(np.array(pseudo_label.cpu()))
         pseudo_weight = torch.sum(ps_large_p).item() / ps_size
         pseudo_weight = pseudo_weight * torch.ones(
             pseudo_prob.shape, device=logits.device)
-        return pseudo_label, pseudo_weight
+        return pseudo_label, pseudo_weight, ps_large_p
 
-    def filter_valid_pseudo_region(self, pseudo_weight, valid_pseudo_mask):
+    def filter_valid_pseudo_region(self, pseudo_weight, valid_pseudo_mask,
+                                   confidence_mask=None):
         if self.psweight_ignore_top > 0:
             # Don't trust pseudo-labels in regions with potential
             # rectification artifacts. This can lead to a pseudo-label
             # drift from sky towards building or traffic light.
             assert valid_pseudo_mask is None
             pseudo_weight[:, :self.psweight_ignore_top, :] = 0
+            if confidence_mask is not None:
+                confidence_mask[:, :self.psweight_ignore_top, :] = 0
         if self.psweight_ignore_bottom > 0:
             assert valid_pseudo_mask is None
             pseudo_weight[:, -self.psweight_ignore_bottom:, :] = 0
+            if confidence_mask is not None:
+                confidence_mask[:, -self.psweight_ignore_bottom:, :] = 0
         if valid_pseudo_mask is not None:
             pseudo_weight *= valid_pseudo_mask.squeeze(1)
+            if confidence_mask is not None:
+                confidence_mask *= valid_pseudo_mask.squeeze(1).bool()
+        if confidence_mask is not None:
+            confidence_mask = confidence_mask.bool()
+            return pseudo_weight, confidence_mask
         return pseudo_weight
 
     def forward_train(self,
@@ -345,7 +375,8 @@ class DACS(UDADecorator):
         seg_debug['Source'] = self.get_model().debug_output
         clean_loss, clean_log_vars = self._parse_losses(clean_losses)
         log_vars.update(clean_log_vars)
-        clean_loss.backward(retain_graph=self.enable_fdist)
+        clean_loss.backward(
+            retain_graph=self.enable_fdist or self.enable_contrastive)
         if self.print_grad_magnitude:
             params = self.get_model().backbone.parameters()
             seg_grads = [
@@ -368,7 +399,7 @@ class DACS(UDADecorator):
                 fd_grads = [g2 - g1 for g1, g2 in zip(seg_grads, fd_grads)]
                 grad_mag = calc_grad_magnitude(fd_grads)
                 mmcv.print_log(f'Fdist Grad.: {grad_mag}', 'mmseg')
-        del src_feat, clean_loss
+        del clean_loss
         if self.enable_fdist:
             del feat_loss
 
@@ -384,13 +415,44 @@ class DACS(UDADecorator):
                 target_img, target_img_metas)
             seg_debug['Target'] = self.get_ema_model().debug_output
 
-            pseudo_label, pseudo_weight = self.get_pseudo_label_and_weight(
+            pseudo_label, pseudo_weight, pseudo_confidence = \
+                self.get_pseudo_label_and_weight(
                 ema_logits)
             del ema_logits
 
-            pseudo_weight = self.filter_valid_pseudo_region(
-                pseudo_weight, valid_pseudo_mask)
+            filtered = self.filter_valid_pseudo_region(
+                pseudo_weight, valid_pseudo_mask,
+                pseudo_confidence.float())
+            if isinstance(filtered, tuple):
+                pseudo_weight, pseudo_confidence = filtered
+            else:
+                pseudo_weight = filtered
+                pseudo_confidence = pseudo_confidence & pseudo_weight.bool()
             gt_pixel_weight = torch.ones((pseudo_weight.shape), device=dev)
+
+            if self.enable_contrastive:
+                tgt_feat_full = self.get_model().extract_feat(target_img)
+                src_feat_for_ctr = self._select_contrastive_feat(src_feat)
+                tgt_feat_for_ctr = self._select_contrastive_feat(tgt_feat_full)
+                contrast_out = self.contrastive_align(
+                    src_feat_for_ctr,
+                    gt_semantic_seg,
+                    tgt_feat_for_ctr,
+                    pseudo_label,
+                    pseudo_confidence)
+                if contrast_out is not None:
+                    contrast_losses, contrast_stats = contrast_out
+                    contrast_losses = add_prefix(contrast_losses, 'contrast')
+                    contrast_loss, contrast_log = self._parse_losses(
+                        contrast_losses)
+                    contrast_log.pop('loss', None)
+                    log_vars.update(contrast_log)
+                    for key, val in contrast_stats.items():
+                        if torch.is_tensor(val):
+                            val = val.detach().cpu().item()
+                        log_vars[f'contrast_{key}'] = float(val)
+                    contrast_loss.backward(retain_graph=self.enable_fdist)
+                del tgt_feat_full
 
             # Apply mixing
             mixed_img, mixed_lbl = [None] * batch_size, [None] * batch_size
@@ -424,6 +486,8 @@ class DACS(UDADecorator):
             mix_loss, mix_log_vars = self._parse_losses(mix_losses)
             log_vars.update(mix_log_vars)
             mix_loss.backward()
+
+        del src_feat
 
         # Masked Training
         if self.enable_masking and self.mask_mode.startswith('separate'):

--- a/seg/requirements.txt
+++ b/seg/requirements.txt
@@ -14,6 +14,7 @@ pyparsing==2.4.7
 pytz==2020.1
 PyYAML==5.4.1
 scipy==1.6.3
+scikit-learn==0.24.2
 seaborn==0.11.1
 timm==0.3.2
 torch==1.7.1+cu110

--- a/seg/tools/estimate_inference_cost.py
+++ b/seg/tools/estimate_inference_cost.py
@@ -1,0 +1,402 @@
+"""Utility to estimate inference parameters and FLOPs for segmentation models.
+
+This script builds the model defined by a config file, runs a dummy forward
+pass that mimics inference, and records the floating-point operations executed
+by convolutional, linear, normalization, pooling, and attention layers.  The
+parameter count is computed directly from the instantiated model.  For
+HRDA-style architectures, the dummy forward pass triggers the multi-scale
+sliding-window inference code path, so the reported FLOPs reflect the aggregate
+cost of the detail crops as well as the low-resolution context pass.
+
+Example:
+    python seg/tools/estimate_inference_cost.py \
+        seg/configs/mic/gtaHR2csHR_mic_hrda.py
+"""
+
+import argparse
+import contextlib
+import importlib
+from collections import defaultdict
+from copy import deepcopy
+from typing import Dict, Iterable, Optional, Tuple
+
+import torch
+
+try:
+    from mmcv import Config
+except ModuleNotFoundError as exc:  # pragma: no cover - dependency message
+    raise ModuleNotFoundError(
+        'mmcv is required to parse segmentation configs. Please install '
+        'mmcv-full before using this script.'
+    ) from exc
+
+from mmseg.models import build_segmentor
+
+# The HRDA implementation ships the MixVisionTransformer attention block in the
+# segmentation codebase.  Importing locally avoids relying on external mmcv
+# attention helpers for FLOP accounting.  Some configs also use a CLIP-based
+# adapter that defines its own attention block with a compatible interface, so
+# both variants are detected dynamically.
+from mmseg.models.backbones.mix_transformer import Attention as MixAttention
+
+ClipAttention = None
+for _module_name in (
+    'mmseg.models.backbones.clip_vision_adapter',
+    'mmseg.models.backbones.clip_adapter',
+):
+    with contextlib.suppress(ModuleNotFoundError, ImportError, AttributeError):
+        ClipAttention = getattr(importlib.import_module(_module_name), 'Attention')
+        break
+
+
+UNITS = ['', 'K', 'M', 'G', 'T', 'P']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Estimate inference parameter and FLOP cost for a config.')
+    parser.add_argument('config', help='Path to the segmentation config file.')
+    parser.add_argument(
+        '--input-shape',
+        type=int,
+        nargs=2,
+        metavar=('HEIGHT', 'WIDTH'),
+        default=None,
+        help='Explicit input resolution (defaults to the config test pipeline).',
+    )
+    parser.add_argument(
+        '--device',
+        default='cpu',
+        choices=['cpu', 'cuda'],
+        help='Device used for the dummy forward pass.',
+    )
+    parser.add_argument(
+        '--no-summary',
+        action='store_true',
+        help='Only print the total counts (omit the detailed breakdown).',
+    )
+    return parser.parse_args()
+
+
+def human_readable(num: float, suffixes: Iterable[str]) -> str:
+    value = float(num)
+    for suffix in suffixes:
+        if abs(value) < 1000:
+            return f'{value:.2f}{suffix}'
+        value /= 1000.0
+    return f'{value:.2f}{suffixes[-1]}'
+
+
+def infer_input_shape(cfg: Config) -> Optional[Tuple[int, int]]:
+    """Extract an input tensor shape from the test pipeline if possible."""
+
+    data_cfg = cfg.get('data') or {}
+    test_cfg = data_cfg.get('test') or {}
+    pipeline = test_cfg.get('pipeline', [])
+    for step in pipeline:
+        if step.get('type') == 'MultiScaleFlipAug':
+            img_scale = step.get('img_scale') or step.get('img_scales')
+            if isinstance(img_scale, (tuple, list)):
+                # mmseg specifies scales as (W, H)
+                if isinstance(img_scale[0], (list, tuple)):
+                    # Take the first scale if multi-scale inference is listed.
+                    width, height = img_scale[0]
+                else:
+                    width, height = img_scale
+                return height, width
+    return None
+
+
+def count_parameters(model: torch.nn.Module) -> int:
+    return sum(p.numel() for p in model.parameters() if p.requires_grad)
+
+
+def prod(values: Iterable[int]) -> int:
+    result = 1
+    for value in values:
+        result *= int(value)
+    return result
+
+
+def conv2d_flops(module: torch.nn.Conv2d, inputs, outputs) -> int:
+    out = outputs if isinstance(outputs, torch.Tensor) else outputs[0]
+    batch_size, out_channels, out_h, out_w = out.shape
+    kernel_h, kernel_w = module.kernel_size
+    in_channels = module.in_channels
+    groups = module.groups
+    filters_per_channel = in_channels // groups
+    conv_per_position_flops = kernel_h * kernel_w * filters_per_channel * 2
+    active_elements_count = batch_size * out_h * out_w * out_channels
+    total_flops = conv_per_position_flops * active_elements_count
+    if module.bias is not None:
+        total_flops += batch_size * out_channels * out_h * out_w
+    return int(total_flops)
+
+
+def linear_flops(module: torch.nn.Linear, inputs, outputs) -> int:
+    input_tensor = inputs[0]
+    if input_tensor.dim() == 1:
+        num_instances = 1
+        in_features = input_tensor.numel()
+    else:
+        num_instances = prod(input_tensor.shape[:-1])
+        in_features = input_tensor.shape[-1]
+    out_features = module.out_features
+    total_flops = 2 * num_instances * in_features * out_features
+    if module.bias is not None:
+        total_flops += num_instances * out_features
+    return int(total_flops)
+
+
+def batchnorm_flops(module: torch.nn.BatchNorm2d, inputs, outputs) -> int:
+    out = outputs if isinstance(outputs, torch.Tensor) else outputs[0]
+    return int(2 * out.numel())
+
+
+def layernorm_flops(module: torch.nn.LayerNorm, inputs, outputs) -> int:
+    inp = inputs[0]
+    return int(5 * inp.numel())
+
+
+def avgpool_flops(module: torch.nn.AvgPool2d, inputs, outputs) -> int:
+    inp = inputs[0]
+    output = outputs if isinstance(outputs, torch.Tensor) else outputs[0]
+    kernel_h = module.kernel_size if isinstance(module.kernel_size, int) else module.kernel_size[0]
+    kernel_w = module.kernel_size if isinstance(module.kernel_size, int) else module.kernel_size[1]
+    return int(prod(output.shape) * (kernel_h * kernel_w))
+
+
+def adaptive_avgpool_flops(module: torch.nn.AdaptiveAvgPool2d, inputs, outputs) -> int:
+    inp = inputs[0]
+    output = outputs if isinstance(outputs, torch.Tensor) else outputs[0]
+    num_elements = prod(inp.shape)
+    out_elements = prod(output.shape)
+    kernel_ops = num_elements // out_elements
+    return int(out_elements * kernel_ops)
+
+
+def attention_flops(module, inputs, outputs) -> int:
+    # MixVisionTransformer attention receives (x, H, W) whereas the CLIP vision
+    # adapter passes explicit query/key/value tensors followed by (H, W).
+    if len(inputs) >= 3 and isinstance(inputs[1], torch.Tensor):
+        query = inputs[0]
+        key = inputs[1]
+        value = inputs[2]
+        B, num_queries, channels = query.shape
+        num_heads = getattr(module, 'num_heads', 1)
+        head_dim = channels // max(num_heads, 1)
+        sr_ratio = getattr(module, 'sr_ratio', 1)
+        kv_tokens = key.shape[1]
+        if sr_ratio > 1 and len(inputs) >= 5:
+            try:
+                height = int(inputs[3])
+                width = int(inputs[4])
+            except (TypeError, ValueError):
+                height = width = 0
+            if height > 0 and width > 0:
+                kv_tokens = (height // sr_ratio) * (width // sr_ratio)
+        flops_qk = B * num_heads * num_queries * kv_tokens * head_dim * 2
+        flops_attn_v = B * num_heads * num_queries * head_dim * kv_tokens * 2
+        return int(flops_qk + flops_attn_v)
+
+    x, H, W = inputs
+    B, N, C = x.shape
+    num_heads = module.num_heads
+    head_dim = C // num_heads
+    if module.sr_ratio > 1:
+        kv_tokens = (H // module.sr_ratio) * (W // module.sr_ratio)
+    else:
+        kv_tokens = N
+    flops_qk = B * num_heads * N * kv_tokens * head_dim * 2
+    flops_attn_v = B * num_heads * N * head_dim * kv_tokens * 2
+    return int(flops_qk + flops_attn_v)
+
+
+def multihead_attention_flops(module: torch.nn.MultiheadAttention, inputs, outputs) -> int:
+    query = inputs[0]
+    key = inputs[1] if len(inputs) > 1 and inputs[1] is not None else query
+    value = inputs[2] if len(inputs) > 2 and inputs[2] is not None else key
+
+    if module.batch_first:
+        batch_size, query_len, q_embed = query.shape
+        _, key_len, k_embed = key.shape
+        _, value_len, v_embed = value.shape
+    else:
+        query_len, batch_size, q_embed = query.shape
+        key_len, _, k_embed = key.shape
+        value_len, _, v_embed = value.shape
+
+    embed_dim = module.embed_dim
+    num_heads = module.num_heads
+    head_dim = embed_dim // max(num_heads, 1)
+
+    q_proj = 2 * batch_size * query_len * q_embed * embed_dim
+    k_proj = 2 * batch_size * key_len * k_embed * embed_dim
+    v_proj = 2 * batch_size * value_len * v_embed * embed_dim
+    bias_ops = 0
+    if module.in_proj_bias is not None:
+        bias_ops = batch_size * (query_len + key_len + value_len) * embed_dim
+
+    attn_scores = 2 * batch_size * num_heads * query_len * key_len * head_dim
+    attn_weighted = 2 * batch_size * num_heads * query_len * head_dim * value_len
+
+    return int(q_proj + k_proj + v_proj + bias_ops + attn_scores + attn_weighted)
+
+
+FLOP_HANDLERS: Dict[type, callable] = {
+    torch.nn.Conv2d: conv2d_flops,
+    torch.nn.Linear: linear_flops,
+    torch.nn.BatchNorm2d: batchnorm_flops,
+    torch.nn.LayerNorm: layernorm_flops,
+    torch.nn.AvgPool2d: avgpool_flops,
+    torch.nn.AdaptiveAvgPool2d: adaptive_avgpool_flops,
+    torch.nn.MultiheadAttention: multihead_attention_flops,
+}
+
+if MixAttention is not None:
+    FLOP_HANDLERS[MixAttention] = attention_flops
+if ClipAttention is not None:
+    FLOP_HANDLERS[ClipAttention] = attention_flops
+
+
+class FlopAnalyzer:
+
+    def __init__(self, module: torch.nn.Module):
+        self.module = module
+        self.handles = []
+        self.flops: Dict[str, int] = defaultdict(int)
+
+    def _make_hook(self, cls):
+        handler = FLOP_HANDLERS[cls]
+
+        def hook(mod, inputs, outputs):
+            self.flops[cls.__name__] += handler(mod, inputs, outputs)
+
+        return hook
+
+    def add_hooks(self):
+        for mod in self.module.modules():
+            for cls in FLOP_HANDLERS:
+                if isinstance(mod, cls):
+                    self.handles.append(mod.register_forward_hook(self._make_hook(cls)))
+
+    def clear(self):
+        for handle in self.handles:
+            handle.remove()
+        self.handles.clear()
+
+    def total(self) -> int:
+        return int(sum(self.flops.values()))
+
+
+def build_model(cfg: Config) -> torch.nn.Module:
+    cfg = cfg.copy()
+    model_cfg = deepcopy(cfg.model)
+    model_cfg.setdefault('train_cfg', None)
+    model_cfg.setdefault('test_cfg', None)
+    if 'pretrained' in model_cfg:
+        model_cfg['pretrained'] = None
+    backbone_cfg = model_cfg.get('backbone')
+    if isinstance(backbone_cfg, dict) and backbone_cfg.get('init_cfg'):
+        backbone_cfg = deepcopy(backbone_cfg)
+        backbone_cfg['init_cfg'] = None
+        model_cfg['backbone'] = backbone_cfg
+    model = build_segmentor(model_cfg)
+    model.eval()
+    return model
+
+
+def compute_hrda_crop_count(model: torch.nn.Module, height: int, width: int) -> Optional[int]:
+    if not hasattr(model, 'scales') or not hasattr(model, 'hr_slide_inference'):
+        return None
+    scales = getattr(model, 'scales')
+    if len(scales) <= 1 or not getattr(model, 'hr_slide_inference'):
+        return None
+    crop_size = getattr(model, 'crop_size', None)
+    if crop_size is None:
+        return None
+    hr_scale = scales[-1]
+    scaled_h = int(round(height * hr_scale))
+    scaled_w = int(round(width * hr_scale))
+    crop_h, crop_w = crop_size
+    if getattr(model, 'hr_slide_overlapping', True):
+        stride_h = crop_h // 2
+        stride_w = crop_w // 2
+    else:
+        stride_h, stride_w = crop_h, crop_w
+    h_grids = max(scaled_h - crop_h + stride_h - 1, 0) // stride_h + 1
+    w_grids = max(scaled_w - crop_w + stride_w - 1, 0) // stride_w + 1
+    return h_grids * w_grids
+
+
+def analyze(cfg_path: str, input_shape: Optional[Tuple[int, int]], device: str,
+            verbose: bool) -> None:
+    cfg = Config.fromfile(cfg_path)
+    inferred_shape = input_shape or infer_input_shape(cfg)
+    if inferred_shape is None:
+        raise ValueError(
+            'Unable to infer an input resolution from the config. Please pass '
+            '--input-shape H W explicitly.')
+    height, width = inferred_shape
+    model = build_model(cfg)
+
+    dummy = torch.randn(1, 3, height, width)
+    device_ctx = contextlib.nullcontext()
+    if device == 'cuda':
+        device_ctx = torch.cuda.device('cuda:0')
+    with device_ctx:
+        if device == 'cuda' and not torch.cuda.is_available():
+            raise RuntimeError('CUDA requested but no GPU is available.')
+        model = model.to(device)
+        dummy = dummy.to(device)
+        analyzer = FlopAnalyzer(model)
+        analyzer.add_hooks()
+        try:
+            with torch.no_grad():
+                if hasattr(model, 'forward_dummy'):
+                    model.forward_dummy(dummy)
+                elif hasattr(model, 'encode_decode'):
+                    model.encode_decode(dummy, None)
+                else:
+                    raise AttributeError(
+                        'The model does not implement forward_dummy() or ' \
+                        'encode_decode(), so inference FLOPs cannot be ' \
+                        'estimated.'
+                    )
+        finally:
+            analyzer.clear()
+
+    total_flops = analyzer.total()
+    params = count_parameters(model)
+    crop_count = compute_hrda_crop_count(model, height, width)
+
+    print(f'Config: {cfg_path}')
+    print(f'Input shape: {height}x{width}')
+    if crop_count is not None:
+        crop_size = getattr(model, 'crop_size')
+        print(
+            f'HRDA detail crops: {crop_count} (crop size {crop_size[0]}x{crop_size[1]}, '
+            f'scales={list(getattr(model, "scales"))})'
+        )
+    print(f'Parameters: {params:,} ({human_readable(params, UNITS)})')
+    print(
+        f'FLOPs: {total_flops:,} '
+        f'({human_readable(total_flops, UNITS)})'
+    )
+    if verbose:
+        for name, value in sorted(analyzer.flops.items()):
+            print(f'  {name:<18}: {human_readable(value, UNITS)}')
+
+
+def main():
+    args = parse_args()
+    analyze(
+        cfg_path=args.config,
+        input_shape=tuple(args.input_shape) if args.input_shape else None,
+        device=args.device,
+        verbose=not args.no_summary,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/seg/tools/plot_target_tsne.py
+++ b/seg/tools/plot_target_tsne.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""Plot a t-SNE visualization for the target domain of a UDA segmentation model.
+
+The script loads a model configuration and checkpoint, extracts logits for
+pixels belonging to each class from the target domain dataset configured in the
+UDA training recipe, and renders a t-SNE scatter plot where each point
+represents a pixel-level logit vector colored by its (ground-truth or predicted)
+class.
+"""
+
+import argparse
+import copy
+import random
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+import matplotlib
+
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from sklearn.manifold import TSNE
+
+import mmcv
+from mmcv import Config
+from mmcv.runner import load_checkpoint
+from mmcv.utils import DictAction
+
+from mmseg.datasets import build_dataset
+from mmseg.models import build_segmentor
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments for the visualization script."""
+
+    default_device = 'cuda:0' if torch.cuda.is_available() else 'cpu'
+    parser = argparse.ArgumentParser(
+        description='Plot a t-SNE embedding for target-domain logits',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument('config', help='path to the mmsegmentation config file')
+    parser.add_argument('checkpoint', help='path to a trained checkpoint file')
+    parser.add_argument(
+        '--output',
+        default='work_dirs/tsne_target.png',
+        help='file to store the resulting plot',
+    )
+    parser.add_argument(
+        '--save-data',
+        default=None,
+        help='optional path to store the sampled logits and labels as a .npz file',
+    )
+    parser.add_argument(
+        '--save-embedding',
+        default=None,
+        help='optional path to store the computed 2-D t-SNE embedding (.npy)',
+    )
+    parser.add_argument(
+        '--max-images',
+        type=int,
+        default=0,
+        help='limit the number of target images processed (0 means all images)',
+    )
+    parser.add_argument(
+        '--max-per-class',
+        type=int,
+        default=2048,
+        help='maximum number of pixel logits sampled per class (<=0 disables the limit)',
+    )
+    parser.add_argument(
+        '--perplexity',
+        type=float,
+        default=30.0,
+        help='perplexity parameter passed to sklearn.manifold.TSNE',
+    )
+    parser.add_argument(
+        '--point-size',
+        type=float,
+        default=6.0,
+        help='marker size used when plotting the scatter points',
+    )
+    parser.add_argument(
+        '--alpha',
+        type=float,
+        default=0.65,
+        help='marker alpha channel used for the scatter plot',
+    )
+    parser.add_argument(
+        '--figsize',
+        type=float,
+        nargs=2,
+        default=(10.0, 10.0),
+        metavar=('WIDTH', 'HEIGHT'),
+        help='size of the matplotlib figure in inches',
+    )
+    parser.add_argument(
+        '--device',
+        default=default_device,
+        help='device used for forward passes during feature extraction',
+    )
+    parser.add_argument(
+        '--seed',
+        type=int,
+        default=0,
+        help='random seed for reproducible sampling and t-SNE initialization',
+    )
+    parser.add_argument(
+        '--use-predictions',
+        action='store_true',
+        help='color samples by predicted classes instead of ground-truth labels',
+    )
+    parser.add_argument(
+        '--cfg-options',
+        nargs='+',
+        action=DictAction,
+        help='override some settings in the used config file, key=value',
+    )
+    return parser.parse_args()
+
+
+def set_random_seed(seed: Optional[int]) -> None:
+    """Seed Python, NumPy, and PyTorch RNGs for reproducibility."""
+
+    if seed is None:
+        return
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def build_target_dataset(cfg: Config) -> object:
+    """Instantiate the target-domain dataset defined in the training config."""
+
+    if 'train' not in cfg.data or 'target' not in cfg.data.train:
+        raise KeyError('The provided config does not define a target training dataset.')
+    target_cfg = copy.deepcopy(cfg.data.train.target)
+    target_cfg.setdefault('test_mode', False)
+    dataset = build_dataset(target_cfg)
+    if not hasattr(dataset, 'CLASSES'):
+        raise AttributeError('The constructed dataset does not expose class metadata.')
+    collect = getattr(getattr(dataset, 'pipeline', None), 'transforms', None)
+    collect = collect[-1] if collect else None
+    keys = getattr(collect, 'keys', [])
+    if 'gt_semantic_seg' not in keys:
+        mmcv.print_log(
+            'Warning: target pipeline does not collect ground-truth annotations. '
+            'Consider enabling --use-predictions to color by inferred classes.',
+            'tsne')
+    return dataset
+
+
+def prepare_model(cfg: Config, checkpoint_path: str, device: torch.device) -> torch.nn.Module:
+    """Build the segmentation model and restore weights from ``checkpoint_path``."""
+
+    cfg = copy.deepcopy(cfg)
+    cfg.model.setdefault('pretrained', None)
+    cfg.model.train_cfg = None
+    model = build_segmentor(cfg.model, test_cfg=cfg.get('test_cfg'))
+    load_checkpoint(model, checkpoint_path, map_location='cpu')
+    model.to(device)
+    model.eval()
+    return model
+
+
+def _extract_sample(
+        dataset,
+        model: torch.nn.Module,
+        device: torch.device,
+        index: int,
+        use_predictions: bool,
+        generator: torch.Generator,
+        max_per_class: Optional[int],
+        class_buffers: List[List[torch.Tensor]],
+        class_counts: List[int],
+        max_classes: int,
+) -> None:
+    """Process a single dataset sample and append logits to ``class_buffers``."""
+
+    sample = dataset[index]
+    if 'img' not in sample:
+        raise KeyError('Sample does not contain an ``img`` key required for inference.')
+
+    img = sample['img']
+    if hasattr(img, 'data'):
+        img_tensor = img.data
+    else:
+        img_tensor = img
+    if img_tensor.dim() == 3:
+        img_tensor = img_tensor.unsqueeze(0)
+    if img_tensor.dim() != 4 or img_tensor.size(0) != 1:
+        raise ValueError(f'Unexpected image tensor shape: {tuple(img_tensor.shape)}')
+    img_tensor = img_tensor.to(device)
+
+    img_metas_container = sample.get('img_metas')
+    if img_metas_container is None:
+        raise KeyError('Sample does not contain ``img_metas`` required by encode_decode.')
+    img_metas = img_metas_container.data if hasattr(img_metas_container, 'data') else img_metas_container
+    img_metas = [img_metas]
+
+    gt_container = sample.get('gt_semantic_seg')
+    if gt_container is not None:
+        gt = gt_container.data if hasattr(gt_container, 'data') else gt_container
+        gt = gt.squeeze(0).long().cpu()
+    else:
+        gt = None
+
+    with torch.no_grad():
+        logits = model.encode_decode(img_tensor, img_metas)
+    logits = logits.squeeze(0).cpu()  # (num_classes, H, W)
+    pred_labels = logits.argmax(dim=0)
+
+    if gt is None and not use_predictions:
+        raise RuntimeError(
+            'Ground-truth annotations are required unless --use-predictions is enabled.')
+
+    if gt is not None:
+        valid_mask = gt != dataset.ignore_index
+    else:
+        valid_mask = torch.ones_like(pred_labels, dtype=torch.bool)
+
+    label_source = pred_labels if use_predictions or gt is None else gt
+
+    flat_logits = logits.permute(1, 2, 0).reshape(-1, logits.shape[0])
+    flat_labels = label_source.reshape(-1)
+    valid_mask = valid_mask.reshape(-1)
+
+    flat_logits = flat_logits[valid_mask]
+    flat_labels = flat_labels[valid_mask]
+
+    if flat_logits.numel() == 0:
+        return
+
+    unique_labels = flat_labels.unique()
+    for cls_idx_tensor in unique_labels:
+        cls_idx = int(cls_idx_tensor.item())
+        if cls_idx < 0 or cls_idx >= max_classes:
+            continue
+        cls_mask = flat_labels == cls_idx
+        cls_logits = flat_logits[cls_mask]
+        if cls_logits.size(0) == 0:
+            continue
+        if max_per_class is not None:
+            remaining = max_per_class - class_counts[cls_idx]
+            if remaining <= 0:
+                continue
+            if cls_logits.size(0) > remaining:
+                perm = torch.randperm(cls_logits.size(0), generator=generator)
+                cls_logits = cls_logits[perm[:remaining]]
+        class_buffers[cls_idx].append(cls_logits)
+        class_counts[cls_idx] += cls_logits.size(0)
+
+
+def collect_logits(
+        dataset,
+        model: torch.nn.Module,
+        device: torch.device,
+        max_images: Optional[int],
+        max_per_class: Optional[int],
+        use_predictions: bool,
+        seed: Optional[int],
+) -> Tuple[torch.Tensor, torch.Tensor, List[int]]:
+    """Iterate over the target dataset and gather per-class logits."""
+
+    num_classes = len(dataset.CLASSES)
+    buffers: List[List[torch.Tensor]] = [[] for _ in range(num_classes)]
+    counts: List[int] = [0 for _ in range(num_classes)]
+    generator = torch.Generator(device='cpu')
+    if seed is not None:
+        generator.manual_seed(seed)
+    processed = 0
+    total = len(dataset) if max_images is None else min(max_images, len(dataset))
+    print(f'Collecting logits from {total} target samples...')
+
+    for idx in range(len(dataset)):
+        if max_images is not None and processed >= max_images:
+            break
+        _extract_sample(
+            dataset,
+            model,
+            device,
+            idx,
+            use_predictions,
+            generator,
+            max_per_class,
+            buffers,
+            counts,
+            num_classes,
+        )
+        processed += 1
+        if total:
+            print(f'  Processed {processed}/{total} images', end='\r')
+        if max_per_class is not None and all(c >= max_per_class for c in counts):
+            break
+
+    print(f'  Processed {processed}/{total} images')
+
+    collected_features: List[torch.Tensor] = []
+    collected_labels: List[torch.Tensor] = []
+    for cls_idx, chunks in enumerate(buffers):
+        if not chunks:
+            continue
+        feats = torch.cat(chunks, dim=0)
+        collected_features.append(feats)
+        collected_labels.append(
+            torch.full((feats.size(0),), cls_idx, dtype=torch.long))
+
+    if not collected_features:
+        raise RuntimeError('No logits were collected. Verify dataset and model outputs.')
+
+    features = torch.cat(collected_features, dim=0)
+    labels = torch.cat(collected_labels, dim=0)
+    return features, labels, counts
+
+
+def run_tsne(features: np.ndarray, perplexity: float, seed: Optional[int]) -> np.ndarray:
+    """Compute the 2-D t-SNE embedding for the collected features."""
+
+    num_samples = features.shape[0]
+    if num_samples < 2:
+        raise RuntimeError('At least two feature vectors are required for t-SNE.')
+    max_perplexity = max(1.0, float(num_samples - 1))
+    effective_perplexity = min(perplexity, max_perplexity)
+    if effective_perplexity >= num_samples:
+        effective_perplexity = max(1.0, num_samples - 1.0)
+    tsne = TSNE(
+        n_components=2,
+        init='pca',
+        random_state=seed,
+        perplexity=effective_perplexity,
+        learning_rate='auto',
+    )
+    return tsne.fit_transform(features)
+
+
+def plot_embedding(
+        embedding: np.ndarray,
+        labels: np.ndarray,
+        class_names: Sequence[str],
+        palette: Sequence[Sequence[int]],
+        counts: Sequence[int],
+        output_path: Path,
+        point_size: float,
+        alpha: float,
+        figsize: Tuple[float, float],
+        title: str,
+) -> None:
+    """Render and store the final scatter plot."""
+
+    fig, ax = plt.subplots(figsize=figsize)
+    unique_labels = np.unique(labels)
+    colors = np.array(palette, dtype=np.float32) / 255.0
+    for cls_idx in unique_labels:
+        cls_idx = int(cls_idx)
+        mask = labels == cls_idx
+        color = colors[cls_idx] if cls_idx < len(colors) else None
+        class_name = class_names[cls_idx] if cls_idx < len(class_names) else str(cls_idx)
+        ax.scatter(
+            embedding[mask, 0],
+            embedding[mask, 1],
+            s=point_size,
+            c=[color],
+            alpha=alpha,
+            edgecolors='none',
+            label=f'{class_name} ({counts[cls_idx]})',
+        )
+    ax.set_title(title)
+    ax.set_xlabel('t-SNE dimension 1')
+    ax.set_ylabel('t-SNE dimension 2')
+    ax.set_xticks([])
+    ax.set_yticks([])
+    ax.legend(loc='center left', bbox_to_anchor=(1.02, 0.5), frameon=False)
+    fig.tight_layout(rect=[0, 0, 0.8, 1])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=300)
+    plt.close(fig)
+
+
+def maybe_save_array(path: Optional[str], array: np.ndarray) -> None:
+    """Persist ``array`` to ``path`` when provided."""
+
+    if path is None:
+        return
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    np.save(output_path, array)
+    print(f'Saved array to {output_path}')
+
+
+def maybe_save_npz(path: Optional[str], **tensors: np.ndarray) -> None:
+    """Store multiple arrays in an ``.npz`` archive when ``path`` is provided."""
+
+    if path is None:
+        return
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(output_path, **tensors)
+    print(f'Saved features to {output_path}')
+
+
+def main() -> None:
+    args = parse_args()
+    device = torch.device(args.device)
+    if device.type == 'cuda' and not torch.cuda.is_available():
+        raise RuntimeError('CUDA device requested but CUDA is not available.')
+
+    set_random_seed(args.seed)
+
+    cfg = Config.fromfile(args.config)
+    if args.cfg_options is not None:
+        cfg.merge_from_dict(args.cfg_options)
+
+    dataset = build_target_dataset(cfg)
+    print(f'Target dataset: {dataset.__class__.__name__} with {len(dataset)} samples')
+
+    model = prepare_model(cfg, args.checkpoint, device)
+
+    max_images = args.max_images if args.max_images > 0 else None
+    max_per_class = args.max_per_class if args.max_per_class > 0 else None
+
+    features, labels, counts = collect_logits(
+        dataset,
+        model,
+        device,
+        max_images=max_images,
+        max_per_class=max_per_class,
+        use_predictions=args.use_predictions,
+        seed=args.seed,
+    )
+
+    features_np = features.numpy().astype(np.float32)
+    labels_np = labels.numpy().astype(np.int32)
+
+    print('Collected samples per class:')
+    for idx, (name, count) in enumerate(zip(dataset.CLASSES, counts)):
+        status = ''
+        if max_per_class is not None and count < max_per_class:
+            status = ' (insufficient)'  # Not enough samples collected for this class
+        print(f'  [{idx:02d}] {name:<16}: {count}{status}')
+
+    embedding = run_tsne(features_np, args.perplexity, args.seed)
+    title = f'Target t-SNE ({Path(args.config).stem})'
+    output_path = Path(args.output)
+    plot_embedding(
+        embedding,
+        labels_np,
+        dataset.CLASSES,
+        dataset.PALETTE,
+        counts,
+        output_path,
+        point_size=args.point_size,
+        alpha=args.alpha,
+        figsize=tuple(args.figsize),
+        title=title,
+    )
+    print(f'Saved t-SNE visualization to {output_path}')
+
+    maybe_save_npz(args.save_data, features=features_np, labels=labels_np)
+    maybe_save_array(args.save_embedding, embedding)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- introduce a reusable `ClasswiseContrastiveLoss` that forms class prototypes from source/target features and optimizes an InfoNCE alignment objective
- integrate the contrastive objective into the DACS training loop with confidence-masked pseudo labels and feature selection helpers
- enable the new loss through the gtaHR2csHR_mic_hrda configuration with temperature, sampling, and weighting knobs

## Testing
- python -m compileall seg/mmseg/models/uda/classwise_contrast.py seg/mmseg/models/uda/dacs.py seg/configs/mic/gtaHR2csHR_mic_hrda.py
- python -m compileall seg/mmseg/models/uda/__init__.py
- python -m compileall seg/mmseg/models/uda/dacs.py

------
https://chatgpt.com/codex/tasks/task_e_68cea7bfacd48324b28ac9235fc0befc